### PR TITLE
Refactoring users model for TADA

### DIFF
--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -77,22 +77,22 @@ class User(AbstractBaseUser, PermissionsMixin):
     USERNAME_FIELD = 'mobile_no'
 
     def save(self, *args, **kwargs):
-        if not self.id:
-            self.generate_sms_pin()
-            self.send_otp()
+        # if not self.id:
+        #     self.generate_sms_pin()
+        #     self.send_otp()
         
         return super(User, self).save(*args, **kwargs)
 
     def generate_email_token(self):
         self.email_verification_code = uuid.uuid4().hex
 
-    def generate_sms_pin(self):
-        pin = ''.join([str(random.choice(range(1, 9))) for i in range(5)])
-        self.sms_verification_pin = int(pin)
+    # def generate_sms_pin(self):
+    #     pin = ''.join([str(random.choice(range(1, 9))) for i in range(5)])
+    #     self.sms_verification_pin = int(pin)
 
-    def send_otp(self):
-        msg = 'Your one time password for ILP is %s. Please enter this on our web page or mobile app to verify your mobile number.' % self.sms_verification_pin
-        send_sms(self.mobile_no, msg)
+    # def send_otp(self):
+    #     msg = 'Your one time password for ILP is %s. Please enter this on our web page or mobile app to verify your mobile number.' % self.sms_verification_pin
+    #     send_sms(self.mobile_no, msg)
 
     def get_token(self):
         return Token.objects.get(user=self).key

--- a/apps/users/serializers/__init__.py
+++ b/apps/users/serializers/__init__.py
@@ -1,0 +1,2 @@
+from .serializers import *
+from .tadaserializers import *

--- a/apps/users/serializers/serializers.py
+++ b/apps/users/serializers/serializers.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import authenticate
 from rest_framework import serializers
 
-from .models import User
+from users.models import User
 
 class TadaUserRegistrationSerializer(serializers.ModelSerializer):
     password = serializers.CharField(
@@ -85,7 +85,6 @@ class UserLoginSerializer(serializers.Serializer):
         fields = ('username', 'password', )
 
     def get_groups(self, obj):
-        print("Inside of get_groups")
         user = obj
         groups = user.groups.all().values('name')
         print("Groups the user is a part of: ", groups)

--- a/apps/users/serializers/tadaserializers.py
+++ b/apps/users/serializers/tadaserializers.py
@@ -1,0 +1,37 @@
+from rest_framework import serializers
+
+from users.models import User
+
+class TadaUserRegistrationSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(
+        style={'input_type': 'password'},
+        write_only=True
+    )
+
+    class Meta:
+        exclude = (
+            'is_email_verified',
+            'email_verification_code',
+        )
+        model = User
+    
+    def create(self, validated_data):
+        groups = validated_data.pop('groups')
+        user = User.objects.create(**validated_data)
+        for group_name in groups:
+            group_obj = Group.objects.get(name=group_name)
+        return user
+
+    def update(self, instance, validated_data):
+        instance.email = validated_data.get('email', instance.email)
+        instance.content = validated_data.get('content', instance.content)
+        instance.created = validated_data.get('created', instance.created)
+        instance.save()
+        return instance
+
+    def get_groups(self, obj):
+        user = obj
+        groups = user.groups.all().values('name')
+        if user.is_superuser:
+            groups = ['tada_admin']
+        return groups

--- a/apps/users/tests.py
+++ b/apps/users/tests.py
@@ -1,6 +1,0 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-from django.test import TestCase
-
-# Create your tests here.

--- a/apps/users/tests/test_fixtures/auth_groups.json
+++ b/apps/users/tests/test_fixtures/auth_groups.json
@@ -1,0 +1,37 @@
+[
+    {
+        "model": "auth.group",
+        "fields":{
+            "id": "1",
+            "name": "ilp_auth_user" 
+        }
+    },
+    {
+        "model": "auth.group",
+        "fields":{
+            "id": "2",
+            "name": "ilp_konnect_user" 
+        }
+    },
+    {
+        "model": "auth.group",
+        "fields":{
+            "id": "3",
+            "name": "tada_deo" 
+        }
+    },
+    {
+        "model": "auth.group",
+        "fields":{
+            "id": "4",
+            "name": "tada_dee" 
+        }
+    },
+    {
+        "model": "auth.group",
+        "fields":{
+            "id": "5",
+            "name": "tada_admin" 
+        }
+    }
+]

--- a/apps/users/tests/tests.py
+++ b/apps/users/tests/tests.py
@@ -1,0 +1,82 @@
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from users.models import  User
+
+
+class UserTests(APITestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        call_command('loaddata',
+                     'apps/users/tests/test_fixtures/auth_groups')
+       
+    def setUp(self):
+        pass
+
+    def test_user_auth_flow(self):
+        url = reverse('user:user-register')
+        print("===========================")
+        print("Testing user registration URL: ", url)
+        print("===========================")
+        response = self.client.post(
+            url, {
+                "email": "test_user@klp.org.in",
+                "mobile_no": "5555533321",
+                "password": "sametime",
+                "first_name": "Test",
+                "last_name": "User"
+            }
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(
+            set(['id', 'groups', 'email', 'mobile_no', 'first_name', 'last_name']).issubset(response.data.keys())
+        )
+        created_user_id = response.data['id']
+        
+        # Retrieve the User object
+        user = User.objects.get(id=created_user_id)
+        verify_pin = user.sms_verification_pin
+        mobile_no = user.mobile_no
+        self.assertIsNotNone(verify_pin)
+        self.verify_otp_password(mobile_no, verify_pin)
+
+        #retrieve the user obejct again and check the status
+        user = User.objects.get(id=created_user_id)
+        self.assertTrue(user.is_active)
+        print("User is now active")
+
+        #Attempt login
+        self.login(user.mobile_no, 'sametime')
+        print("===========================")
+        print("User auth flow test complete")
+        print("===========================")
+
+    def login(self, username, password):
+        url = reverse('user:user-login')
+        print("Attempting to login user with username %s" % username)
+        response = self.client.post(url,
+            {
+                "username": username,
+                "password": password
+            }
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        print("User successfully logged in")
+
+
+    def verify_otp_password(self, mobile_no, pin):
+        url = reverse('user:api_otp_update')
+        print("Verifying user %s using PIN" % mobile_no)
+        response = self.client.post(
+            url, {
+                "mobile_no": mobile_no,
+                "otp": pin
+            }
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        print("User successfully verified")

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -9,6 +9,9 @@ from .views import (
     OtpPasswordResetView
 )
 
+from users.views import (
+    TadaUserRegisterView
+)
 urlpatterns = [
     url(
         r'^users/register/$',
@@ -37,4 +40,12 @@ urlpatterns = [
     ),
 
     url('^users/profile', UserProfileView.as_view(), name='api_user_profile'),
+
+    #TADA urls
+
+    url(
+        r'^users/tada/register/$',
+        TadaUserRegisterView.as_view(),
+        name='tada-user-register'
+    )
 ]

--- a/apps/users/views/__init__.py
+++ b/apps/users/views/__init__.py
@@ -1,0 +1,2 @@
+from .tadaviews import *
+from .views import *

--- a/apps/users/views/tadaviews.py
+++ b/apps/users/views/tadaviews.py
@@ -1,0 +1,32 @@
+from rest_framework import generics, permissions, status
+from rest_framework.response import Response
+
+from users.models import User
+from users.serializers import (
+    TadaUserRegistrationSerializer
+)
+from users.permission import IsAdminOrIsSelf
+from django.contrib.auth.models import Group
+
+
+class TadaUserRegisterView(generics.CreateAPIView):
+    """
+    This endpoint registers a new TADA user
+    """
+    permission_classes =(
+        permissions.IsAdminUser
+    )
+    serializer_class = TadaUserRegistrationSerializer
+
+    def perform_create(self,serializer):
+        instance = serializer.save()
+        groups = request.POST.get('groups','')
+        for group in groups:
+            try:
+                group_name = Group.objects.get(name=group)
+                print("Group name is: ", group_name.name)
+            except Group.DoesNotExist:
+                pass
+            else:
+                instance.groups.add(group_name)
+                print("Added group %s to user instance", group_name.name)


### PR DESCRIPTION
- Have created new folders for serializers/views etc..to keep tada/ilp files separate. Will lead to less merge conflicts in the future when apps are modified
- Have created a tests folder and test fixtures to test the auth registration flow
- Have moved sending of OTP SMS PIN from model into the view 
- Email verification is still handled in the Django signal when the User model is saved.
@ansal See above.