### PR TITLE
Trying to fix guardian user object permissions for anon user

### DIFF
--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -143,3 +143,7 @@ class UserBoundary(models.Model):
 
     class Meta:
         unique_together = (('user', 'boundary'), )
+
+''' This is specifically for django-guardian '''
+def get_anonymous_user_instance(User):
+    return User(first_name='Anonymous', last_name='Anonymous', mobile_no='00000000000')

--- a/apps/users/serializers/serializers.py
+++ b/apps/users/serializers/serializers.py
@@ -3,27 +3,6 @@ from rest_framework import serializers
 
 from users.models import User
 
-class TadaUserRegistrationSerializer(serializers.ModelSerializer):
-    password = serializers.CharField(
-        style={'input_type': 'password'},
-        write_only=True
-    )
-
-    class Meta:
-        exclude = (
-            'is_email_verified',
-            'email_verification_code',
-        )
-        model = User
-    
-    def get_groups(self, obj):
-        user = obj
-        groups = user.groups.all().values('name')
-        if user.is_superuser:
-            groups = ['tada_admin']
-        return groups
-
-
 class UserSerializer(serializers.ModelSerializer):
     is_active = serializers.BooleanField(read_only=True)
     is_staff = serializers.BooleanField(read_only=True)

--- a/apps/users/views/tadaviews.py
+++ b/apps/users/views/tadaviews.py
@@ -21,12 +21,4 @@ class TadaUserRegisterView(generics.CreateAPIView):
     def perform_create(self,serializer):
         instance = serializer.save()
         groups = request.POST.get('groups','')
-        for group in groups:
-            try:
-                group_name = Group.objects.get(name=group)
-                print("Group name is: ", group_name.name)
-            except Group.DoesNotExist:
-                pass
-            else:
-                instance.groups.add(group_name)
-                print("Added group %s to user instance", group_name.name)
+    

--- a/ilp/settings/base.py
+++ b/ilp/settings/base.py
@@ -187,6 +187,8 @@ EMAIL_DEFAULT_FROM = 'India Learning Partnership <dev@ilp.org.in>'
 
 SITE_ID = 1
 
+#Django-guardian settings
+ANONYMOUS_USER_NAME = None
 
 # Logging
 LOG_ROOT = os.path.join(BASE_DIR, "/logs")


### PR DESCRIPTION
Disabled creation of anon users by guardian since we don't need anon user object level permisisons